### PR TITLE
Update _member-show.scss

### DIFF
--- a/app/assets/stylesheets/members/_member-show.scss
+++ b/app/assets/stylesheets/members/_member-show.scss
@@ -26,7 +26,7 @@
 
   .media .pull-left {
     padding: 0;
-    margin-right: 15px;
+    margin-right: 10px;
   }
 
   .object-data-rebellion small,


### PR DESCRIPTION
This pull request aims to fix the issue https://github.com/openaustralia/publicwhip/issues/1078 (Member header layouts differ between pages where they shouldn't)
The space to the right of the members photo is wider by 5px on the member show page than the divisions index with member page. So, the space has been made same on both the pages.